### PR TITLE
Support release namespace for helm

### DIFF
--- a/examples/helm-generator.md
+++ b/examples/helm-generator.md
@@ -28,6 +28,7 @@ metadata:
   name: ignored
 
 releaseName: elasticsearch
+releaseNamespace: elasticsearch
 chart: elasticsearch
 version: 1.31.1
 repo: https://kubernetes-charts.storage.googleapis.com/

--- a/internal/helm/executor.go
+++ b/internal/helm/executor.go
@@ -51,7 +51,7 @@ func (helm *Executor) command(args ...string) *exec.Cmd {
 }
 
 // Template renders a chart archive using the specified release name and value overrides
-func (helm *Executor) Template(name, chart, version, repo string, values []Value) ([]byte, error) {
+func (helm *Executor) Template(name, chart, version, namespace, repo string, values []Value) ([]byte, error) {
 	// Construct the arguments
 	var args []string
 	args = append(args, "template")
@@ -65,6 +65,9 @@ func (helm *Executor) Template(name, chart, version, repo string, values []Value
 
 	if version != "" {
 		args = append(args, "--version", version)
+	}
+	if namespace != "" {
+		args = append(args, "--namespace", namespace)
 	}
 	if repo != "" {
 		args = append(args, "--repo", repo)

--- a/plugin/helm/generator/command.go
+++ b/plugin/helm/generator/command.go
@@ -41,6 +41,7 @@ func NewHelmGeneratorCommand() *cobra.Command {
 	// These flags match what real Helm has
 	cmd.Flags().StringVar(&p.Repository, "repo", "", "repository `url` used to locate the chart")
 	cmd.Flags().StringVarP(&p.ReleaseName, "name", "n", "release-name", "release `name`")
+	cmd.Flags().StringVarP(&p.ReleaseNamespace, "namespace", "s", "release-namespace", "release `namespace`")
 	cmd.Flags().StringVar(&p.Version, "version", "", "fetch a specific `version` of a chart; if empty, the latest version of the chart will be used")
 	cmd.Flags().StringVar(&p.Helm.RepositoryCache, "repository-cache", "", "override the `directory` of your cached Helm repository index")
 	cmd.Flags().StringToStringVar(&f.set, "set", nil, "set `value`s on the command line")

--- a/plugin/helm/generator/command.go
+++ b/plugin/helm/generator/command.go
@@ -40,7 +40,7 @@ func NewHelmGeneratorCommand() *cobra.Command {
 
 	// These flags match what real Helm has
 	cmd.Flags().StringVar(&p.Repository, "repo", "", "repository `url` used to locate the chart")
-	cmd.Flags().StringVarP(&p.ReleaseName, "name", "release-name", "release `name`")
+	cmd.Flags().StringVarP(&p.ReleaseName, "name", "", "release-name", "release `name`")
 	cmd.Flags().StringVarP(&p.ReleaseNamespace, "namespace", "n", "release-namespace", "release `namespace`")
 	cmd.Flags().StringVar(&p.Version, "version", "", "fetch a specific `version` of a chart; if empty, the latest version of the chart will be used")
 	cmd.Flags().StringVar(&p.Helm.RepositoryCache, "repository-cache", "", "override the `directory` of your cached Helm repository index")

--- a/plugin/helm/generator/command.go
+++ b/plugin/helm/generator/command.go
@@ -40,8 +40,8 @@ func NewHelmGeneratorCommand() *cobra.Command {
 
 	// These flags match what real Helm has
 	cmd.Flags().StringVar(&p.Repository, "repo", "", "repository `url` used to locate the chart")
-	cmd.Flags().StringVarP(&p.ReleaseName, "name", "n", "release-name", "release `name`")
-	cmd.Flags().StringVarP(&p.ReleaseNamespace, "namespace", "s", "release-namespace", "release `namespace`")
+	cmd.Flags().StringVarP(&p.ReleaseName, "name", "release-name", "release `name`")
+	cmd.Flags().StringVarP(&p.ReleaseNamespace, "namespace", "n", "release-namespace", "release `namespace`")
 	cmd.Flags().StringVar(&p.Version, "version", "", "fetch a specific `version` of a chart; if empty, the latest version of the chart will be used")
 	cmd.Flags().StringVar(&p.Helm.RepositoryCache, "repository-cache", "", "override the `directory` of your cached Helm repository index")
 	cmd.Flags().StringToStringVar(&f.set, "set", nil, "set `value`s on the command line")

--- a/plugin/helm/generator/command.go
+++ b/plugin/helm/generator/command.go
@@ -40,7 +40,7 @@ func NewHelmGeneratorCommand() *cobra.Command {
 
 	// These flags match what real Helm has
 	cmd.Flags().StringVar(&p.Repository, "repo", "", "repository `url` used to locate the chart")
-	cmd.Flags().StringVarP(&p.ReleaseName, "name", "", "release-name", "release `name`")
+	cmd.Flags().StringVar(&p.ReleaseName, "name", "release-name", "release `name`")
 	cmd.Flags().StringVarP(&p.ReleaseNamespace, "namespace", "n", "release-namespace", "release `namespace`")
 	cmd.Flags().StringVar(&p.Version, "version", "", "fetch a specific `version` of a chart; if empty, the latest version of the chart will be used")
 	cmd.Flags().StringVar(&p.Helm.RepositoryCache, "repository-cache", "", "override the `directory` of your cached Helm repository index")

--- a/plugin/helm/generator/helm_generator.go
+++ b/plugin/helm/generator/helm_generator.go
@@ -28,13 +28,14 @@ import (
 type plugin struct {
 	h *resmap.PluginHelpers
 
-	Helm         helm.Executor `json:"helm"`
-	ReleaseName  string        `json:"releaseName"`
-	Chart        string        `json:"chart"`
-	Version      string        `json:"version"`
-	Repository   string        `json:"repo"`
-	Values       []helm.Value  `json:"values"`
-	IncludeTests bool          `json:"includeTests"`
+	Helm             helm.Executor `json:"helm"`
+	ReleaseName      string        `json:"releaseName"`
+	ReleaseNamespace string        `json:"releaseNamespace"`
+	Chart            string        `json:"chart"`
+	Version          string        `json:"version"`
+	Repository       string        `json:"repo"`
+	Values           []helm.Value  `json:"values"`
+	IncludeTests     bool          `json:"includeTests"`
 }
 
 //noinspection GoUnusedGlobalVariable
@@ -47,7 +48,7 @@ func (p *plugin) Config(h *resmap.PluginHelpers, c []byte) error {
 
 func (p *plugin) Generate() (resmap.ResMap, error) {
 	// Render the chart
-	b, err := p.Helm.Template(p.ReleaseName, p.Chart, p.Version, p.Repository, p.Values)
+	b, err := p.Helm.Template(p.ReleaseName, p.Chart, p.Version, p.ReleaseNamespace, p.Repository, p.Values)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Helm charts often make decisions about when they use or omit namespaces for resources. Although Kustomize has a way of enforcing a namespace for the whole kustomization, a user may not always want that.

Allowing one to specify the release namespace which is an actual helm feature gives the user one more knob to control the generator's output. 