### PR TITLE
Improvements to the writers

### DIFF
--- a/pkg/konjure/writer.go
+++ b/pkg/konjure/writer.go
@@ -57,8 +57,18 @@ func (w *Writer) Write(nodes []*yaml.RNode) error {
 			Sort:                  w.Sort,
 		}
 
-	case "ndjson", "json":
-		ww = &NDJSONWriter{
+	case "json":
+		ww = &JSONWriter{
+			Writer:                w.Writer,
+			KeepReaderAnnotations: w.KeepReaderAnnotations,
+			ClearAnnotations:      w.ClearAnnotations,
+			WrappingAPIVersion:    "v1",
+			WrappingKind:          "List",
+			Sort:                  w.Sort,
+		}
+
+	case "ndjson":
+		ww = &JSONWriter{
 			Writer:                w.Writer,
 			KeepReaderAnnotations: w.KeepReaderAnnotations,
 			ClearAnnotations:      w.ClearAnnotations,
@@ -77,16 +87,18 @@ func (w *Writer) Write(nodes []*yaml.RNode) error {
 	return ww.Write(nodes)
 }
 
-// NDJSONWriter is a writer which emits JSON instead of YAML. This is useful if you like jq.
-type NDJSONWriter struct {
+// JSONWriter is a writer which emits JSON instead of YAML. This is useful if you like `jq`.
+type JSONWriter struct {
 	Writer                io.Writer
 	KeepReaderAnnotations bool
 	ClearAnnotations      []string
+	WrappingKind          string
+	WrappingAPIVersion    string
 	Sort                  bool
 }
 
 // Write encodes each node as a single line of JSON.
-func (w *NDJSONWriter) Write(nodes []*yaml.RNode) error {
+func (w *JSONWriter) Write(nodes []*yaml.RNode) error {
 	if w.Sort {
 		if err := kioutil.SortNodes(nodes); err != nil {
 			return err
@@ -108,13 +120,38 @@ func (w *NDJSONWriter) Write(nodes []*yaml.RNode) error {
 				return err
 			}
 		}
-
-		if err := enc.Encode(n); err != nil {
-			return err
-		}
 	}
 
-	return nil
+	if w.WrappingKind == "" {
+		for i := range nodes {
+			if err := enc.Encode(nodes[i]); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	items := &yaml.Node{Kind: yaml.SequenceNode}
+	for i := range nodes {
+		items.Content = append(items.Content, nodes[i].YNode())
+	}
+
+	return enc.Encode(yaml.NewRNode(&yaml.Node{
+		Kind: yaml.DocumentNode,
+		Content: []*yaml.Node{
+			{
+				Kind: yaml.MappingNode,
+				Content: []*yaml.Node{
+					{Kind: yaml.ScalarNode, Value: "apiVersion"},
+					{Kind: yaml.ScalarNode, Value: w.WrappingAPIVersion},
+					{Kind: yaml.ScalarNode, Value: "kind"},
+					{Kind: yaml.ScalarNode, Value: w.WrappingKind},
+					{Kind: yaml.ScalarNode, Value: "items"},
+					items,
+				},
+			},
+		},
+	}))
 }
 
 // EnvWriter is a writer which only emits name/value pairs found in the data of config maps and secrets.


### PR DESCRIPTION
This PR fixes a couple gaps I noticed:

1. There is no way to set the shell for `--output env`, now we consider the `SHELL` environment variable (and I added in fish support)
2. Currently `json` and `ndjson` both produce NDJSON, I changed the `NDJSONWriter` to `JSONWriter` and added the same wrapper config found in the KYAML `ByteWriter`. When no wrapper is configured the writer produces NDJSON, when the wrapper is configured it produces an `items` list in JSON. To be consistent with `kubectl`, the new behavior when you use `--output json` will be to produce a `v1/List` (and you can still use `--output ndjson` to get NDJSON, i.e. one resource per line).