### PR TITLE
Fix inline resources

### DIFF
--- a/internal/spec/parser.go
+++ b/internal/spec/parser.go
@@ -53,6 +53,11 @@ func (p *Parser) Decode(spec string) (interface{}, error) {
 		return &kio.ByteReader{Reader: p.Reader}, nil
 	}
 
+	// Inline resources
+	if strings.ContainsRune(spec, '\n') {
+		return &kio.ByteReader{Reader: strings.NewReader(spec)}, nil
+	}
+
 	// Absolute file path
 	if filepath.IsAbs(spec) {
 		return &konjurev1beta2.File{Path: spec}, nil

--- a/internal/spec/parser_test.go
+++ b/internal/spec/parser_test.go
@@ -92,6 +92,13 @@ func TestParser_Decode(t *testing.T) {
 			},
 		},
 		{
+			desc: "data URI base64",
+			spec: "data:;base64,SGVsbG8sIFdvcmxkIQ==",
+			expected: &kio.ByteReader{
+				Reader: bytes.NewReader([]byte("Hello, World!")),
+			},
+		},
+		{
 			desc: "helm repo without path",
 			parser: Parser{HelmRepositoryConfig: HelmRepositoryConfig{Repositories: []HelmRepository{
 				{Name: "stable", URL: "https://kubernetes-charts.storage.googleapis.com"},


### PR DESCRIPTION
Currently Konjure supports inline resources via the `data:` URL; this works in the CLI but fails in the public API because the `konjure.Resource` can only map to a single `RNode`. This PR makes `konjure.Resource` implement `kio.Reader` (instead of just offering the `GetRNode()` function): this ensures that all of the contents from stream based resource specifications can be supported properly.

Additionally, because it is a pain to have to base 64 encode YAML to create `data:` URLs, this PR also enables plain text "inline resources". Whenever a resource specification spans multiple lines (contains a newline character), it is treated like raw YAML. Note: as with `data:` URLs and the default resource (i.e. the specification "-" which is typically read from stdin), _no validation_ is performed on the input produced by inline resources.