### PR TITLE
Readers cleanup

### DIFF
--- a/internal/readers/filter.go
+++ b/internal/readers/filter.go
@@ -18,7 +18,6 @@ package readers
 
 import (
 	"fmt"
-	"strings"
 
 	konjurev1beta2 "github.com/thestormforge/konjure/pkg/api/core/v1beta2"
 	"sigs.k8s.io/kustomize/kyaml/kio"
@@ -37,9 +36,7 @@ type Filter struct {
 	ReaderOptions []Option
 }
 
-var _ kio.Filter = &Filter{}
-
-// Filter expands all of the Konjure resources using the configured executors.
+// Filter expands all the Konjure resources using the configured executors.
 func (f *Filter) Filter(nodes []*yaml.RNode) ([]*yaml.RNode, error) {
 	return f.filterToDepth(nodes, f.Depth)
 }
@@ -51,94 +48,96 @@ func (f *Filter) filterToDepth(nodes []*yaml.RNode, depth int) ([]*yaml.RNode, e
 		return nodes, nil
 	}
 
-	// Create a new cleaner for this iteration of expansion
-	var cleaners Cleaners
-	defer func() {
-		// TODO This should produce warnings, maybe the errors can be accumulated on the filer itself
-		cleaners.CleanUp()
-	}()
-	opts := append([]Option{cleaners.Register}, f.ReaderOptions...)
+	var opts []Option
+	opts = append(opts, f.ReaderOptions...)
 
-	var result []*yaml.RNode
-	var depthNext int
+	// Create a new cleaner for this iteration
+	cleanOpt, doClean := clean()
+	opts = append(opts, cleanOpt)
+	defer doClean()
+
+	// Process each of the nodes
+	result := make([]*yaml.RNode, 0, len(nodes))
+	done := true
 	for _, n := range nodes {
-		m, err := n.GetMeta()
+		r, err := f.expand(n)
 		if err != nil {
 			return nil, err
 		}
 
-		// Just include non-Konjure resources directly
-		if m.APIVersion != konjurev1beta2.APIVersion {
-			result = append(result, n)
-			continue
+		for _, opt := range opts {
+			r = opt(r)
 		}
 
-		// Only set the depth if we encounter a Konjure resource (which could expand into other Konjure resources)
-		depthNext = depth - 1
-
-		// Create a new typed object from the YAML
-		obj, err := konjurev1beta2.NewForType(&m.TypeMeta)
-		if err != nil {
-			return nil, err
-		}
-		if err := n.YNode().Decode(obj); err != nil {
-			return nil, err
-		}
-
-		// Create a new reader
-		r := New(obj, opts...)
-		if r == nil {
-			return nil, fmt.Errorf("unable to read resources from type: %s", m.Kind)
-		}
-
-		// Accumulate additional resource nodes
 		ns, err := r.Read()
 		if err != nil {
 			return nil, err
 		}
+
 		result = append(result, ns...)
+		done = done && len(ns) == 1 && ns[0] == n
 	}
 
-	return f.filterToDepth(result, depthNext)
-}
-
-// CleanUpError is an aggregation of errors that occur during clean up.
-type CleanUpError []error
-
-// Error returns the newline delimited error strings of all the aggregated errors.
-func (e CleanUpError) Error() string {
-	var errStrings []string
-	for _, err := range e {
-		errStrings = append(errStrings, err.Error())
+	// Perform another iteration if any of the nodes changed
+	if !done {
+		return f.filterToDepth(result, depth-1)
 	}
-	return strings.Join(errStrings, "\n")
+	return result, nil
 }
 
-// Cleaner is an interface for readers that may need to perform clean up of temporary resources.
-type Cleaner interface {
-	Clean() error
-}
-
-// Cleaners is a collection of cleaners that can be invoked together.
-type Cleaners []Cleaner
-
-// Register the supplied reader with this cleaner.
-func (cs *Cleaners) Register(r kio.Reader) kio.Reader {
-	if c, ok := r.(Cleaner); ok {
-		*cs = append(*cs, c)
+// expand returns a reader which can expand the supplied node. If the supplied node
+// cannot be expanded, the resulting reader will only produce that node.
+func (f *Filter) expand(node *yaml.RNode) (kio.Reader, error) {
+	m, err := node.GetMeta()
+	if err != nil {
+		return nil, err
 	}
-	return r
+
+	switch {
+
+	case m.APIVersion == konjurev1beta2.APIVersion:
+		// Unmarshal the typed Konjure resource and create a reader from it
+		res, err := konjurev1beta2.NewForType(&m.TypeMeta)
+		if err != nil {
+			return nil, err
+		}
+		if err := node.YNode().Decode(res); err != nil {
+			return nil, err
+		}
+		r := New(res)
+		if r == nil {
+			return nil, fmt.Errorf("unable to read resources from type: %s", m.Kind)
+		}
+		return r, nil
+
+	default:
+		// The default behavior is to just return the node itself
+		return kio.ResourceNodeSlice{node}, nil
+	}
 }
 
-// CleanUp invokes all of the cleaners, individual failures are aggregated and
-// will not prevent other clean up tasks from being executed.
-func (cs Cleaners) CleanUp() error {
-	var errs CleanUpError
-	for _, c := range cs {
-		if err := c.Clean(); err != nil {
-			errs = append(errs, err)
+// cleaner can be implemented by readers to implement clean up logic after a filter iteration.
+type cleaner interface{ Clean() error }
+
+// clean is used to discover readers which implement `cleaner` and invoke their `Clean` function.
+func clean() (cleanOpt Option, doClean func()) {
+	var cleaners []cleaner
+
+	// Accumulate cleaner instances using a reader option
+	cleanOpt = func(r kio.Reader) kio.Reader {
+		if c, ok := r.(cleaner); ok {
+			cleaners = append(cleaners, c)
+		}
+		return r
+	}
+
+	// Invoke all the `cleaner.Clean()` functions
+	doClean = func() {
+		for _, c := range cleaners {
+			// TODO This should produce warnings, maybe the errors can be accumulated on the filer itself
+			_ = c.Clean()
 		}
 	}
 
-	return errs
+	return
 }

--- a/internal/readers/helm.go
+++ b/internal/readers/helm.go
@@ -85,7 +85,7 @@ func (helm *HelmReader) Read() ([]*yaml.RNode, error) {
 		}
 	}
 
-	p := &Pipeline{Inputs: []kio.Reader{cmd}}
+	p := &filters.Pipeline{Inputs: []kio.Reader{cmd}}
 
 	if !helm.IncludeTests {
 		p.Filters = append(p.Filters, &filters.ResourceMetaFilter{

--- a/internal/readers/kubernetes.go
+++ b/internal/readers/kubernetes.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	konjurev1beta2 "github.com/thestormforge/konjure/pkg/api/core/v1beta2"
+	"github.com/thestormforge/konjure/pkg/filters"
 	"sigs.k8s.io/kustomize/kyaml/yaml"
 )
 
@@ -37,7 +38,7 @@ type KubernetesReader struct {
 }
 
 func (k *KubernetesReader) Read() ([]*yaml.RNode, error) {
-	p := &Pipeline{}
+	p := &filters.Pipeline{}
 
 	namespaces, err := k.namespaces()
 	if err != nil {

--- a/internal/readers/options.go
+++ b/internal/readers/options.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2021 GramLabs, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package readers
+
+import (
+	"io"
+	"path/filepath"
+
+	"sigs.k8s.io/kustomize/kyaml/kio"
+)
+
+// WithDefaultInputStream overrides the default input stream of stdin.
+func WithDefaultInputStream(defaultReader io.Reader) Option {
+	return func(r kio.Reader) kio.Reader {
+		if rr, ok := r.(*ResourceReader); ok && rr.Reader == nil {
+			rr.Reader = defaultReader
+		}
+		return r
+	}
+}
+
+// WithWorkingDirectory sets the base directory to resolve relative paths against.
+func WithWorkingDirectory(dir string) Option {
+	abs := func(path string) (string, error) {
+		if filepath.IsAbs(path) {
+			return filepath.Clean(path), nil
+		}
+		return filepath.Join(dir, path), nil
+	}
+
+	return func(r kio.Reader) kio.Reader {
+		if fr, ok := r.(*FileReader); ok {
+			fr.Abs = abs
+		}
+		return r
+	}
+}
+
+// WithRecursiveDirectories controls the behavior for traversing directories.
+func WithRecursiveDirectories(recurse bool) Option {
+	return func(r kio.Reader) kio.Reader {
+		if fr, ok := r.(*FileReader); ok {
+			fr.Recurse = recurse
+		}
+		return r
+	}
+}
+
+// WithKubeconfig controls the default path of the kubeconfig file.
+func WithKubeconfig(kubeconfig string) Option {
+	return func(r kio.Reader) kio.Reader {
+		if kr, ok := r.(*KubernetesReader); ok {
+			kr.Kubeconfig = kubeconfig
+		}
+		return r
+	}
+}
+
+// WithKubectlExecutor controls the alternate executor for kubectl.
+func WithKubectlExecutor(executor Executor) Option {
+	return func(r kio.Reader) kio.Reader {
+		if kr, ok := r.(*KubernetesReader); ok {
+			kr.Executor = executor
+		}
+		return r
+	}
+}
+
+// WithKustomizeExecutor controls the alternate executor for kustomize.
+func WithKustomizeExecutor(executor Executor) Option {
+	return func(r kio.Reader) kio.Reader {
+		if kr, ok := r.(*KustomizeReader); ok {
+			kr.Executor = executor
+		}
+		return r
+	}
+}

--- a/internal/readers/options.go
+++ b/internal/readers/options.go
@@ -23,6 +23,9 @@ import (
 	"sigs.k8s.io/kustomize/kyaml/kio"
 )
 
+// Option is used to configure or decorate a reader.
+type Option func(r kio.Reader) kio.Reader
+
 // WithDefaultInputStream overrides the default input stream of stdin.
 func WithDefaultInputStream(defaultReader io.Reader) Option {
 	return func(r kio.Reader) kio.Reader {

--- a/internal/readers/readers.go
+++ b/internal/readers/readers.go
@@ -28,9 +28,6 @@ import (
 	"sigs.k8s.io/kustomize/kyaml/yaml"
 )
 
-// Option is used to configure or decorate a reader.
-type Option func(r kio.Reader) kio.Reader
-
 // New returns a resource node reader or nil if the input is not recognized.
 func New(obj interface{}, opts ...Option) kio.Reader {
 	// Construct a new reader based on the input type

--- a/internal/readers/readers.go
+++ b/internal/readers/readers.go
@@ -29,38 +29,29 @@ import (
 )
 
 // New returns a resource node reader or nil if the input is not recognized.
-func New(obj interface{}, opts ...Option) kio.Reader {
+func New(res interface{}) kio.Reader {
 	// Construct a new reader based on the input type
-	var r kio.Reader
-	switch res := obj.(type) {
+	switch res := res.(type) {
 	case *konjurev1beta2.Resource:
-		r = &ResourceReader{Resources: res.Resources}
+		return &ResourceReader{Resources: res.Resources}
 	case *konjurev1beta2.Helm:
-		r = &HelmReader{Helm: *res}
+		return &HelmReader{Helm: *res}
 	case *konjurev1beta2.Jsonnet:
-		r = NewJsonnetReader(res)
+		return NewJsonnetReader(res)
 	case *konjurev1beta2.Kubernetes:
-		r = &KubernetesReader{Kubernetes: *res}
+		return &KubernetesReader{Kubernetes: *res}
 	case *konjurev1beta2.Kustomize:
-		r = &KustomizeReader{Kustomize: *res}
+		return &KustomizeReader{Kustomize: *res}
 	case *konjurev1beta2.Secret:
-		r = &SecretReader{Secret: *res}
+		return &SecretReader{Secret: *res}
 	case *konjurev1beta2.Git:
-		r = &GitReader{Git: *res}
+		return &GitReader{Git: *res}
 	case *konjurev1beta2.HTTP:
-		r = &HTTPReader{HTTP: *res}
+		return &HTTPReader{HTTP: *res}
 	case *konjurev1beta2.File:
-		r = &FileReader{File: *res}
-	default:
-		return nil
+		return &FileReader{File: *res}
 	}
-
-	// Apply reader options
-	for _, opt := range opts {
-		r = opt(r)
-	}
-
-	return r
+	return nil
 }
 
 // Executor is function that returns the output of a command.

--- a/internal/readers/readers.go
+++ b/internal/readers/readers.go
@@ -111,34 +111,3 @@ func (cmd *command) Read() ([]*yaml.RNode, error) {
 
 	return kio.FromBytes(out)
 }
-
-// Pipeline wraps a KYAML pipeline but doesn't allow writers: instead the
-// resulting resource nodes are returned directly. This is useful for applying
-// filters to readers in memory. A pipeline can also be used as a reader in
-// larger pipelines.
-type Pipeline struct {
-	Inputs                []kio.Reader
-	Filters               []kio.Filter
-	ContinueOnEmptyResult bool
-}
-
-// Execute this pipeline, returning the resulting resource nodes directly.
-func (p *Pipeline) Read() ([]*yaml.RNode, error) {
-	var result []*yaml.RNode
-
-	pp := kio.Pipeline{
-		Inputs:                p.Inputs,
-		Filters:               p.Filters,
-		ContinueOnEmptyResult: p.ContinueOnEmptyResult,
-		Outputs: []kio.Writer{kio.WriterFunc(func(nodes []*yaml.RNode) error {
-			result = nodes
-			return nil
-		})},
-	}
-
-	if err := pp.Execute(); err != nil {
-		return nil, err
-	}
-
-	return result, nil
-}

--- a/internal/readers/readers.go
+++ b/internal/readers/readers.go
@@ -33,7 +33,7 @@ func New(res interface{}) kio.Reader {
 	// Construct a new reader based on the input type
 	switch res := res.(type) {
 	case *konjurev1beta2.Resource:
-		return &ResourceReader{Resources: res.Resources}
+		return &ResourceReader{Resource: *res}
 	case *konjurev1beta2.Helm:
 		return &HelmReader{Helm: *res}
 	case *konjurev1beta2.Jsonnet:

--- a/internal/readers/resource.go
+++ b/internal/readers/resource.go
@@ -29,7 +29,7 @@ import (
 // ResourceReader generates Konjure resource nodes by parsing the configured resource specifications.
 type ResourceReader struct {
 	// The list of resource specifications to generate Konjure resources from.
-	Resources []string
+	konjurev1beta2.Resource
 	// The byte stream of (possibly non-Konjure) resources to read give the
 	// resource specification of "-". Defaults to `os.Stdin`.
 	Reader io.Reader


### PR DESCRIPTION
This is mostly just shuffling code around, the only major changes come to the `readers.Filter` type (the commit history gives a reasonable explanation of the changes).

For the `readers.Filter` the big change is around breaking up the main expansion loop; I broke out a chunk of the loop into its own `expand` function that takes an arbitrary `RNode` and returns the corresponding `kio.Reader` (even if that reader just returns the same node). This should make it easier for Konjure to expand other resources in the future.