### PR TITLE
Add a "name" output option

### DIFF
--- a/internal/command/root.go
+++ b/internal/command/root.go
@@ -79,7 +79,7 @@ func NewRootCommand(version, refspec, date string) *cobra.Command {
 	cmd.Flags().BoolVar(&f.Format, "format", false, "format output to Kubernetes conventions")
 	cmd.Flags().BoolVarP(&f.RecursiveDirectories, "recurse", "r", false, "recursively process directories")
 	cmd.Flags().StringVar(&f.Kubeconfig, "kubeconfig", "", "path to the kubeconfig file")
-	cmd.Flags().StringVarP(&w.Format, "output", "o", "yaml", "set the output format (yaml, json, ndjson, env)")
+	cmd.Flags().StringVarP(&w.Format, "output", "o", "yaml", "set the output format (yaml, json, ndjson, name, env)")
 	cmd.Flags().BoolVar(&w.KeepReaderAnnotations, "keep-annotations", false, "retain annotations used for processing")
 	cmd.Flags().BoolVar(&w.Sort, "sort", false, "sort output prior to writing")
 


### PR DESCRIPTION
Nothing earth shattering here, let's you use `konjure -o name ...` to just print object names.

The change looks bigger then it is because I moved the "wrapping" logic from the JSON writer to a shared function.