### PR TITLE
Add a hidden option for restoring vertical white space

### DIFF
--- a/internal/command/root.go
+++ b/internal/command/root.go
@@ -78,11 +78,14 @@ func NewRootCommand(version, refspec, date string) *cobra.Command {
 	cmd.Flags().BoolVar(&f.KeepStatus, "keep-status", false, "retain status fields, if present")
 	cmd.Flags().BoolVar(&f.KeepComments, "keep-comments", true, "retain YAML comments")
 	cmd.Flags().BoolVar(&f.Format, "format", false, "format output to Kubernetes conventions")
+	cmd.Flags().BoolVar(&f.RestoreVerticalWhiteSpace, "vws", false, "attempt to restore vertical white space")
 	cmd.Flags().BoolVarP(&f.RecursiveDirectories, "recurse", "r", false, "recursively process directories")
 	cmd.Flags().StringVar(&f.Kubeconfig, "kubeconfig", "", "path to the kubeconfig file")
 	cmd.Flags().StringVarP(&w.Format, "output", "o", "yaml", "set the output format (yaml, json, ndjson, env, name, columns=, template=)")
 	cmd.Flags().BoolVar(&w.KeepReaderAnnotations, "keep-annotations", false, "retain annotations used for processing")
 	cmd.Flags().BoolVar(&w.Sort, "sort", false, "sort output prior to writing")
+
+	_ = cmd.Flags().MarkHidden("vws")
 
 	cmd.AddCommand(
 		NewHelmCommand(),

--- a/pkg/filters/filters.go
+++ b/pkg/filters/filters.go
@@ -17,6 +17,8 @@ limitations under the License.
 package filters
 
 import (
+	"strings"
+
 	"sigs.k8s.io/kustomize/kyaml/kio"
 	"sigs.k8s.io/kustomize/kyaml/yaml"
 )
@@ -95,3 +97,57 @@ type ReaderFunc func() ([]*yaml.RNode, error)
 
 // Read evaluates the typed function.
 func (f ReaderFunc) Read() ([]*yaml.RNode, error) { return f() }
+
+// RestoreVerticalWhiteSpace tries to put back blank lines eaten by the parser.
+// It's not perfect (it only restores blank lines on the top level), but it helps
+// prevent some changes to YAML sources that contain extra blank lines.
+func RestoreVerticalWhiteSpace() kio.Filter {
+	return kio.FilterAll(yaml.FilterFunc(func(node *yaml.RNode) (*yaml.RNode, error) {
+		n := node.YNode()
+		for i := range n.Content {
+			// No need to insert VWS if we are still on the same line
+			if i == 0 || n.Content[i].Line == n.Content[i-1].Line {
+				continue
+			}
+
+			// Assume all lines before this node's head comment are blank and work back from there
+			ll := n.Content[i].Line - 1
+			if len(n.Content[i].HeadComment) > 0 {
+				ll -= strings.Count(n.Content[i].HeadComment, "\n") + 1
+			}
+
+			// The previous node will have accounted for all the blanks above it
+			ll -= lastLine(n.Content[i-1])
+
+			// The foot comment will be stored two nodes back if this is a mapping node
+			footComment := n.Content[i-1].FootComment
+			if footComment == "" && n.Kind == yaml.MappingNode && i-2 >= 0 {
+				footComment = n.Content[i-2].FootComment
+			}
+			if len(footComment) > 0 {
+				ll -= strings.Count(footComment, "\n") + 2
+			}
+
+			// Check if all the lines are accounted for
+			if ll <= 0 {
+				continue
+			}
+
+			// Prefix the head comment with blank lines
+			n.Content[i].HeadComment = strings.Repeat("\n", ll) + n.Content[i].HeadComment
+		}
+
+		return node, nil
+	}))
+}
+
+// lastLine returns the largest line number from the supplied node.
+func lastLine(n *yaml.Node) int {
+	line := n.Line
+	for i := range n.Content {
+		if ll := lastLine(n.Content[i]); ll > line {
+			line = ll
+		}
+	}
+	return line
+}

--- a/pkg/konjure/filter.go
+++ b/pkg/konjure/filter.go
@@ -41,6 +41,9 @@ type Filter struct {
 	KeepComments bool
 	// Flag indicating that output should be formatted.
 	Format bool
+	// Flag indicating that an attempt should be made to restore vertical
+	// whitespace using line numbers when available.
+	RestoreVerticalWhiteSpace bool
 	// The explicit working directory used to resolve relative paths.
 	WorkingDirectory string
 	// Flag indicating we can process directories recursively.
@@ -84,6 +87,10 @@ func (f *Filter) Filter(nodes []*yaml.RNode) ([]*yaml.RNode, error) {
 
 	if f.Format {
 		p.Filters = append(p.Filters, &kiofilters.FormatFilter{})
+	}
+
+	if f.RestoreVerticalWhiteSpace {
+		p.Filters = append(p.Filters, filters.RestoreVerticalWhiteSpace())
 	}
 
 	return p.Read()


### PR DESCRIPTION
The YAML parser eats vertical white space while parsing, however it keeps the line numbers. This hack attempts to restore some of the vertical white space using the line numbers as guidance. It isn't very reliable, but in some cases VWS is desirable so this is a hidden option for now.