### PR TITLE
fix: Add additional json tags

### DIFF
--- a/pkg/api/core/v1beta2/types.go
+++ b/pkg/api/core/v1beta2/types.go
@@ -149,7 +149,7 @@ type Secret struct {
 	PasswordSources []PasswordRecipe `json:"passwords,omitempty" yaml:"passwords,omitempty"`
 
 	// Additional configuration for generating passwords.
-	PasswordOptions *password.GeneratorInput `json:"passwordOptions,omitempty" yaml:"passwordOptions,omitempty"`
+	PasswordOptions *password.GeneratorInput `json:"-" yaml:"-"`
 }
 
 // Git is used to expand full or partial Git repositories.

--- a/pkg/konjure/resource.go
+++ b/pkg/konjure/resource.go
@@ -44,10 +44,10 @@ type Resource struct {
 	File       *konjurev1beta2.File       `json:"file,omitempty" yaml:"file,omitempty"`
 
 	// Some specs (default reader, `data:` URLs, inline resources) resolve to a stream.
-	raw kio.Reader // NOTE: when this is non-nil there MUST be a value for `str`!
+	raw kio.Reader `json:"-"` // NOTE: when this is non-nil there MUST be a value for `str`!
 
 	// Original string representation this resource was parsed from.
-	str string
+	str string `json:"-"`
 }
 
 // NewResource returns a resource for parsing the supplied resource specifications. This


### PR DESCRIPTION
Not sure if this is really a fix or just bending to the will of controller-gen.
When trying to use `konjure.Resources` in a CRD, controller-gen attempts to validate
every struct has json tags. Even for private fields ( dumb ).

Signed-off-by: Brad Beam <brad.beam@stormforge.io>