### PR TITLE
Add support for CSV output

### DIFF
--- a/internal/command/root.go
+++ b/internal/command/root.go
@@ -81,7 +81,7 @@ func NewRootCommand(version, refspec, date string) *cobra.Command {
 	cmd.Flags().BoolVar(&w.RestoreVerticalWhiteSpace, "vws", false, "attempt to restore vertical white space")
 	cmd.Flags().BoolVarP(&f.RecursiveDirectories, "recurse", "r", false, "recursively process directories")
 	cmd.Flags().StringVar(&f.Kubeconfig, "kubeconfig", "", "path to the kubeconfig file")
-	cmd.Flags().StringVarP(&w.Format, "output", "o", "yaml", "set the output format (yaml, json, ndjson, env, name, columns=, template=)")
+	cmd.Flags().StringVarP(&w.Format, "output", "o", "yaml", "set the output format (yaml, json, ndjson, env, name, columns=, csv=, template=)")
 	cmd.Flags().BoolVar(&w.KeepReaderAnnotations, "keep-annotations", false, "retain annotations used for processing")
 	cmd.Flags().BoolVar(&w.Sort, "sort", false, "sort output prior to writing")
 

--- a/pkg/filters/fieldpath.go
+++ b/pkg/filters/fieldpath.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2022 GramLabs, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package filters
+
+import (
+	"strings"
+	"text/template"
+)
+
+// FieldPath evaluates a path template using the supplied context and then
+// splits it into individual path segments (honoring escaped slashes).
+func FieldPath(p string, data map[string]string) ([]string, error) {
+	// Evaluate the path as a Go Template
+	t, err := template.New("path").
+		Delims("{", "}").
+		Option("missingkey=zero").
+		Parse(p)
+	if err != nil {
+		return nil, err
+	}
+	var pathBuf strings.Builder
+	if err := t.Execute(&pathBuf, data); err != nil {
+		return nil, err
+	}
+
+	// Remove the leading slash to prevent empty elements
+	path := strings.TrimLeft(pathBuf.String(), "/")
+	if path == "" {
+		return nil, nil
+	} else if !strings.Contains(path, `\/`) {
+		return strings.Split(path, "/"), nil
+	}
+
+	// Handle escaped slashes using a temporary placeholder
+	// NOTE: This just mimics the logic of the equivalent code in the Kustomize FieldPath
+	var result []string
+	for _, pp := range strings.Split(strings.ReplaceAll(path, `\/`, `???`), "/") {
+		result = append(result, strings.ReplaceAll(pp, `???`, `/`))
+	}
+	return result, nil
+}

--- a/pkg/konjure/writer_test.go
+++ b/pkg/konjure/writer_test.go
@@ -104,3 +104,44 @@ c: d
 		})
 	}
 }
+
+func TestSplitColumns(t *testing.T) {
+	cases := []struct {
+		desc            string
+		spec            string
+		expectedHeaders []string
+		expectedColumns []string
+	}{
+		{
+			desc:            "default headers",
+			spec:            "foo, bar",
+			expectedHeaders: []string{"FOO", "BAR"},
+			expectedColumns: []string{"foo", "bar"},
+		},
+		{
+			desc:            "default headers from path",
+			spec:            "a.b.c.foo, x.y.z.bar",
+			expectedHeaders: []string{"FOO", "BAR"},
+			expectedColumns: []string{"a.b.c.foo", "x.y.z.bar"},
+		},
+		{
+			desc:            "explicit headers",
+			spec:            "Foo:a.b.c.foo  ,  Bar:x.y.z.bar",
+			expectedHeaders: []string{"Foo", "Bar"},
+			expectedColumns: []string{"a.b.c.foo", "x.y.z.bar"},
+		},
+		{
+			desc:            "escaped column",
+			spec:            ":x:y:z, :a:b.c",
+			expectedHeaders: []string{"X:Y:Z", "C"},
+			expectedColumns: []string{"x:y:z", "a:b.c"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			headers, columns := splitColumns(tc.spec)
+			assert.Equal(t, tc.expectedHeaders, headers)
+			assert.Equal(t, tc.expectedColumns, columns)
+		})
+	}
+}


### PR DESCRIPTION
Basically re-uses the custom column logic to emit proper CSV. Uses YAML paths instead of Go-Templates as column specs.